### PR TITLE
Add route builder

### DIFF
--- a/lib/src/app.dart
+++ b/lib/src/app.dart
@@ -9,7 +9,7 @@ import 'package:taskem/src/common/theme/theme_provider.dart';
 import 'package:taskem/src/core/extensions/context_extension.dart';
 import 'package:taskem/src/features/initialization/model/dependencies.dart';
 import 'package:taskem/src/i18n/translations.g.dart';
-import 'package:taskem/src/routes.dart';
+import 'package:taskem/src/routes/routes.dart';
 
 class MyApp extends StatelessWidget {
   const MyApp({
@@ -30,13 +30,11 @@ class MyApp extends StatelessWidget {
         if (lightDynamic != null && darkDynamic != null) {
           lightColorScheme = lightDynamic.harmonized();
           lightColorScheme = lightColorScheme.copyWith(
-            background: const Color(0xffebebeb),
             surface: const Color(0xffebebeb),
           );
 
           darkColorScheme = darkDynamic.harmonized();
           darkColorScheme = darkColorScheme.copyWith(
-            background: const Color(0xff1a1a1a),
             surface: const Color(0xff1a1a1a),
           );
         } else {
@@ -45,7 +43,6 @@ class MyApp extends StatelessWidget {
           );
           darkColorScheme = ColorScheme.fromSeed(
             seedColor: seedColor,
-            background: const Color(0xff1a1a1a),
             surface: const Color(0xff1a1a1a),
             brightness: Brightness.dark,
           );

--- a/lib/src/core/widgets/info_text.dart
+++ b/lib/src/core/widgets/info_text.dart
@@ -18,7 +18,7 @@ class InfoText extends StatelessWidget {
         Dimension.borderRadius,
       ),
       child: ColoredBox(
-        color: theme.colorScheme.tertiaryContainer,
+        color: theme.colorScheme.onTertiary,
         child: Padding(
           padding: const EdgeInsets.all(12),
           child: Text(

--- a/lib/src/features/authorization/widgets/sign_in/sign_in_form.dart
+++ b/lib/src/features/authorization/widgets/sign_in/sign_in_form.dart
@@ -7,7 +7,8 @@ import 'package:taskem/src/core/helpers/snack_bar_service.dart';
 import 'package:taskem/src/core/widgets/custom_progress_indicator.dart';
 import 'package:taskem/src/core/widgets/custom_text_field.dart';
 import 'package:taskem/src/features/authorization/controllers/auth_bloc.dart';
-import 'package:taskem/src/routes.dart';
+import 'package:taskem/src/routes/routes.dart';
+import 'package:taskem/src/routes/screen_route_builder.dart';
 
 class SignInForm extends StatefulWidget {
   const SignInForm({
@@ -69,7 +70,9 @@ class _SignInFormState extends State<SignInForm> {
                 );
               }
               if (state is AuthSuccessLogin) {
-                context.go(ScreenRoutes.teams.path);
+                context.go(
+                  ScreenRouteBuilder().path(ScreenRoutes.teams).build(),
+                );
               }
             },
             builder: (context, state) {
@@ -110,7 +113,9 @@ class _SignInFormState extends State<SignInForm> {
               const SizedBox(width: 8),
               GestureDetector(
                 onTap: () {
-                  context.go(ScreenRoutes.signUp.path);
+                  context.go(
+                    ScreenRouteBuilder().path(ScreenRoutes.signUp).build(),
+                  );
                 },
                 child: Text(
                   translation.authorization.registration,

--- a/lib/src/features/authorization/widgets/sign_up/sign_up_form.dart
+++ b/lib/src/features/authorization/widgets/sign_up/sign_up_form.dart
@@ -7,7 +7,8 @@ import 'package:taskem/src/core/helpers/snack_bar_service.dart';
 import 'package:taskem/src/core/widgets/custom_progress_indicator.dart';
 import 'package:taskem/src/core/widgets/custom_text_field.dart';
 import 'package:taskem/src/features/authorization/controllers/auth_bloc.dart';
-import 'package:taskem/src/routes.dart';
+import 'package:taskem/src/routes/routes.dart';
+import 'package:taskem/src/routes/screen_route_builder.dart';
 
 class SignUpForm extends StatefulWidget {
   const SignUpForm({
@@ -119,7 +120,9 @@ class _SignUpFormState extends State<SignUpForm> {
                 );
               }
               if (state is AuthSuccessSignUp) {
-                context.go(ScreenRoutes.signIn.path);
+                context.go(
+                  ScreenRouteBuilder().path(ScreenRoutes.signIn).build(),
+                );
                 SnackBarService.info(
                   context,
                   translation.authorization.accountCreated,
@@ -165,7 +168,9 @@ class _SignUpFormState extends State<SignUpForm> {
               const SizedBox(width: 8),
               GestureDetector(
                 onTap: () {
-                  context.go(ScreenRoutes.signIn.path);
+                  context.go(
+                    ScreenRouteBuilder().path(ScreenRoutes.signIn).build(),
+                  );
                 },
                 child: Text(
                   translation.authorization.login,

--- a/lib/src/features/initialization/logic/initialization_processor.dart
+++ b/lib/src/features/initialization/logic/initialization_processor.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/services.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:grpc/grpc.dart';
 import 'package:talker_flutter/talker_flutter.dart';
@@ -45,19 +44,20 @@ final class InitializationProcessor {
       ),
     );
 
-    final byte = await rootBundle.load(_environmentStore.certPath);
+    // final byte = await rootBundle.load(_environmentStore.certPath);
 
     final channel = ClientChannel(
       _environmentStore.host,
       port: _environmentStore.port,
       options: ChannelOptions(
-        credentials: ChannelCredentials.secure(
-          certificates: byte.buffer.asUint8List(),
-          onBadCertificate: (certificate, host) {
-            _talker.error('Bad certificate: $certificate');
-            return false;
-          },
-        ),
+        credentials: ChannelCredentials.insecure(),
+        // credentials: ChannelCredentials.secure(
+        //   certificates: byte.buffer.asUint8List(),
+        //   onBadCertificate: (certificate, host) {
+        //     _talker.error('Bad certificate: $certificate');
+        //     return false;
+        //   },
+        // ),
         keepAlive: const ClientKeepAliveOptions(
           pingInterval: Duration(seconds: 1),
         ),

--- a/lib/src/features/team/screens/team_screen.dart
+++ b/lib/src/features/team/screens/team_screen.dart
@@ -19,7 +19,8 @@ import 'package:taskem/src/features/team/controller/specific_team/specific_team_
 import 'package:taskem/src/features/team/controller/team_task/team_task_bloc.dart';
 import 'package:taskem/src/features/team/models/team_model.dart';
 import 'package:taskem/src/features/team/widgets/loading_widget.dart';
-import 'package:taskem/src/routes.dart';
+import 'package:taskem/src/routes/routes.dart';
+import 'package:taskem/src/routes/screen_route_builder.dart';
 
 part '../widgets/assign_task_form.dart';
 part '../widgets/backlog_widget.dart';

--- a/lib/src/features/team/screens/teams_screen.dart
+++ b/lib/src/features/team/screens/teams_screen.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_animate/flutter_animate.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:taskem/src/core/extensions/context_extension.dart';
 import 'package:taskem/src/core/helpers/dimension.dart';
 import 'package:taskem/src/core/helpers/platform_check_mixin.dart';
 import 'package:taskem/src/core/widgets/info_text.dart';
@@ -25,7 +24,6 @@ class _TeamsScreenState extends State<TeamsScreen>
   @override
   Widget build(BuildContext context) {
     super.build(context);
-    final theme = context.theme;
 
     return Padding(
       padding: EdgeInsets.symmetric(
@@ -39,31 +37,30 @@ class _TeamsScreenState extends State<TeamsScreen>
         },
         builder: (context, state) {
           return switch (state) {
-            TeamsLoaded(teams: final teams) => teams.isNotEmpty
-                ? RefreshIndicator(
-                    onRefresh: () async {
-                      context.read<TeamBloc>().add(const TeamEvent.getTeams());
-                    },
-                    child: CustomScrollView(
-                      slivers: [
-                        SliverList.builder(
-                          itemCount: teams.length,
-                          itemBuilder: (context, index) {
-                            final team = teams[index];
-                            return TeamCard(
-                              team: team,
-                              canJoin: true,
-                            );
-                          },
-                        ),
-                      ],
-                    ).animate().fade(),
-                  )
-                : const Center(
-                    child: InfoText(
-                      title: 'Нет команд',
+            TeamsLoaded(teams: final teams) => RefreshIndicator(
+                onRefresh: () async {
+                  context.read<TeamBloc>().add(const TeamEvent.getTeams());
+                },
+                child: CustomScrollView(
+                  slivers: [
+                    SliverList.builder(
+                      itemCount: teams.length,
+                      itemBuilder: (context, index) {
+                        final team = teams[index];
+                        return TeamCard(
+                          team: team,
+                          canJoin: true,
+                        );
+                      },
                     ),
-                  ).animate().fade(),
+                  ],
+                ).animate().fade(),
+              ),
+            TeamsEmpty() => const Center(
+                child: InfoText(
+                  title: 'Нет команд',
+                ),
+              ).animate().fade(),
             TeamError() => Center(
                 child: TryAgainButton(
                   onPressed: () =>

--- a/lib/src/features/team/screens/user_teams_screen.dart
+++ b/lib/src/features/team/screens/user_teams_screen.dart
@@ -10,7 +10,8 @@ import 'package:taskem/src/features/team/controller/teams/team_bloc.dart';
 import 'package:taskem/src/features/team/controller/user_teams/user_team_bloc.dart';
 import 'package:taskem/src/features/team/widgets/loading_widget.dart';
 import 'package:taskem/src/features/team/widgets/team_card.dart';
-import 'package:taskem/src/routes.dart';
+import 'package:taskem/src/routes/routes.dart';
+import 'package:taskem/src/routes/screen_route_builder.dart';
 
 class UserTeamScreen extends StatefulWidget {
   const UserTeamScreen({required this.onJoinPressed, super.key});
@@ -69,7 +70,10 @@ class _UserTeamScreenState extends State<UserTeamScreen>
                               final team = teams[index];
                               return TeamCard(
                                 onCardPressed: () => context.push(
-                                  '${ScreenRoutes.team.path}/${team.id}',
+                                  ScreenRouteBuilder()
+                                      .path(ScreenRoutes.team)
+                                      .param(team.id)
+                                      .build(),
                                 ),
                                 team: team,
                               );

--- a/lib/src/features/team/widgets/team_loaded.dart
+++ b/lib/src/features/team/widgets/team_loaded.dart
@@ -3,7 +3,6 @@ part of '../screens/team_screen.dart';
 class _TeamLoaded extends StatelessWidget with PlatformCheck {
   const _TeamLoaded({
     required this.team,
-    super.key,
   });
 
   final TeamModel team;
@@ -21,7 +20,11 @@ class _TeamLoaded extends StatelessWidget with PlatformCheck {
       floatingActionButton: FloatingActionButton.extended(
         onPressed: () {
           context.go(
-            '${ScreenRoutes.team.path}/${team.id}/create',
+            ScreenRouteBuilder()
+                .path(ScreenRoutes.team)
+                .param(team.id)
+                .path(ScreenRoutes.createTask)
+                .build(),
             extra: team.members,
           );
         },
@@ -103,7 +106,6 @@ class _TeamTaskCard extends StatelessWidget with PlatformCheck {
   const _TeamTaskCard({
     required this.team,
     required this.task,
-    super.key,
     this.canAssign = true,
   });
 

--- a/lib/src/routes/routes.dart
+++ b/lib/src/routes/routes.dart
@@ -11,6 +11,8 @@ import 'package:taskem/src/features/shared/model/user_info_model.dart';
 import 'package:taskem/src/features/task/screens/create_task_screen.dart';
 import 'package:taskem/src/features/team/screens/root_teams_screen.dart';
 import 'package:taskem/src/features/team/screens/team_screen.dart';
+import 'package:taskem/src/routes/screen_route.dart';
+import 'package:taskem/src/routes/screen_route_builder.dart';
 
 /// [ScreenRoutes] class defines static getters to retrieve instances
 /// of the [ScreenRoute].
@@ -20,35 +22,35 @@ abstract final class ScreenRoutes {
   ///[SignInScreen] route
   static ScreenRoute get signIn => ScreenRoute(
         name: 'signIn',
-        path: '/signIn',
+        path: 'signIn',
         goPath: '/signIn',
       );
 
   ///[SignUpScreen] route
   static ScreenRoute get signUp => ScreenRoute(
         name: 'signUp',
-        path: '/signUp',
+        path: 'signUp',
         goPath: '/signUp',
       );
 
   ///[HomeScreen] route
   static ScreenRoute get home => ScreenRoute(
         name: 'home',
-        path: '/home',
+        path: 'home',
         goPath: '/home',
       );
 
   ///[RootTeamsScreen] route
   static ScreenRoute get teams => ScreenRoute(
         name: 'teams',
-        path: '/teams',
+        path: 'teams',
         goPath: '/teams',
       );
 
   ///[TeamScreen] route
   static ScreenRoute get team => ScreenRoute(
         name: 'team',
-        path: '/teams',
+        path: 'teams',
         goPath: ':id',
       );
 
@@ -65,12 +67,12 @@ abstract final class ScreenRoutes {
 
   static final _router = GoRouter(
     debugLogDiagnostics: true,
-    initialLocation: ScreenRoutes.signIn.path,
+    initialLocation: ScreenRoutes.signIn.goPath,
     routes: [
       GoRoute(
         path: '/',
         redirect: (context, state) {
-          return ScreenRoutes.home.path;
+          return ScreenRouteBuilder().path(ScreenRoutes.home).build();
         },
       ),
       StatefulShellRoute.indexedStack(
@@ -240,24 +242,4 @@ abstract final class ScreenRoutes {
       ),
     ],
   );
-}
-
-/// The [ScreenRoute] class represents a model
-/// for defining routes in the application.
-final class ScreenRoute {
-  ///Constructor
-  ScreenRoute({
-    required this.name,
-    required this.path,
-    required this.goPath,
-  });
-
-  ///Route name
-  final String name;
-
-  ///Route path
-  final String path;
-
-  ///Path in [GoRoute] path
-  final String goPath;
 }

--- a/lib/src/routes/screen_route.dart
+++ b/lib/src/routes/screen_route.dart
@@ -1,0 +1,19 @@
+/// The [ScreenRoute] class represents a model
+/// for defining routes in the application.
+final class ScreenRoute {
+  ///Constructor
+  ScreenRoute({
+    required this.name,
+    required this.path,
+    required this.goPath,
+  });
+
+  ///Route name
+  final String name;
+
+  ///Route path
+  final String path;
+
+  ///Path in [GoRoute] path
+  final String goPath;
+}

--- a/lib/src/routes/screen_route_builder.dart
+++ b/lib/src/routes/screen_route_builder.dart
@@ -1,0 +1,19 @@
+import 'package:taskem/src/routes/screen_route.dart';
+
+final class ScreenRouteBuilder {
+  final List<String> _parts = [];
+
+  ScreenRouteBuilder path(ScreenRoute route) {
+    _parts.add(route.path);
+    return this;
+  }
+
+  ScreenRouteBuilder param<T>(T value) {
+    _parts.add(value.toString());
+    return this;
+  }
+
+  String build() {
+    return '/' + _parts.join('/');
+  }
+}


### PR DESCRIPTION
Now route path can be define using `ScreenRouteBuilder` instead of `ScreenRoutes`

For example:
Before:
```dart
context.go('${ScreenRoutes.team.path}/${team.id}');
``` 
After: 
```dart
context.go(
    ScreenRouteBuilder()
        .path(ScreenRoutes.team)
        .param(team.id)
        .build(),
);
```